### PR TITLE
ENH: Use new image to build environment in

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Pack environment
       run: |
         set -x
-        docker run -v $(pwd)/environment.yml:/tmp/environment.yml \
+        docker run -v $(pwd)/${{ env.ENVIRONMENT_FILE_PATH }}:/tmp/environment.yml \
         -v $(pwd):/tmp/project \
         -v $(pwd)/${{ env.TEST_FILE }}:/tmp/run-test.sh \
         -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.1 /tmp/environment.yml

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ runs:
         docker run -v $(pwd)/${{ env.ENVIRONMENT_FILE_PATH }}:/tmp/environment.yml \
         -v $(pwd):/tmp/project \
         -v $(pwd)/${{ env.TEST_FILE }}:/tmp/run-test.sh \
-        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.1 /tmp/environment.yml
+        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.2 /tmp/environment.yml
       shell: bash
     - name: Copy environment
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ runs:
         docker run -v $(pwd)/${{ env.ENVIRONMENT_FILE_PATH }}:/tmp/environment.yml \
         -v $(pwd):/tmp/project \
         -v $(pwd)/${{ env.TEST_FILE }}:/tmp/run-test.sh \
-        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.2 /tmp/environment.yml
+        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.3 /tmp/environment.yml
       shell: bash
     - name: Copy environment
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ runs:
         docker run -v $(pwd)/environment.yml:/tmp/environment.yml \
         -v $(pwd):/tmp/project \
         -v $(pwd)/${{ env.TEST_FILE }}:/tmp/run-test.sh \
-        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t jgarrahan/lcls-rhel7-conda-docker:v1.0 /tmp/environment.yml
+        -e ENVIRONMENT_NAME=${{ env.ENVIRONMENT_NAME }} --name build-env  -t tidacs/lcls-rhel7-conda-docker:v1.1 /tmp/environment.yml
       shell: bash
     - name: Copy environment
       run: |


### PR DESCRIPTION
More changes I've been holding onto while using the tag from my fork

Uses the tidacs dockerhub image
Allows specifying an environment file to build from
Updates to the most recent version of the rhel7 image
